### PR TITLE
Add final round test

### DIFF
--- a/test_gameplay.py
+++ b/test_gameplay.py
@@ -2,6 +2,7 @@
 """Interactive test for Ticket to Ride gameplay"""
 
 import os
+import pytest
 from ttr_ga.board import Board
 from ttr_ga.player import HumanPlayer, Deck
 from ttr_ga.game import game_loop, GameState, execute_action, check_tickets, longest_continuous_path
@@ -57,6 +58,7 @@ def display_board_status(board):
 
 def test_interactive_gameplay():
     """Test a game with human players interactively"""
+    pytest.skip("Interactive test - skipped during automated testing")
     clear_screen()
     print("=== Ticket To Ride Interactive Gameplay Test ===")
     print("This will start a test game with 2-5 human players.")

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -95,3 +95,15 @@ class TestBoard:
         # Same player attempts to claim second route
         result2 = board.claim_route(player1, city1, city2, player_count=4)
         assert result2 is False  # Should fail regardless of player count
+
+    def test_claim_route_triggers_final_round(self, board, players):
+        """Claiming a route with few trains left should trigger final round"""
+        player1 = players[0]
+        player1.trains = 2
+
+        city1, city2 = "Chicago", "Detroit"
+        board.graph.add_edge(city1, city2, color='blue', length=1)
+
+        result = board.claim_route(player1, city1, city2)
+
+        assert result == (True, "final_round")


### PR DESCRIPTION
## Summary
- skip interactive gameplay test so pytest runs without input
- test that claiming a route with few trains left returns the final round flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e7c815ec83259077e11cc2879595